### PR TITLE
Fix: Allow bookings back-to-back by correcting overlaps() logic

### DIFF
--- a/src/main/java/com/example/Booking.java
+++ b/src/main/java/com/example/Booking.java
@@ -16,7 +16,7 @@ public class Booking {
     }
 
     public boolean overlaps(LocalDateTime start, LocalDateTime end) {
-        return !endTime.isBefore(start) && !startTime.isAfter(end);
+        return start.isBefore(endTime) && end.isAfter(startTime);
     }
 
     public String getId() {


### PR DESCRIPTION
The booking system currently prevents users from booking rooms back-to-back. When one booking ends at 11:00, a new booking cannot start at 11:00, even though these time slots do not actually overlap.